### PR TITLE
Assets autodeploy

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -52,7 +52,7 @@ jobs:
           timeZone: 8
           format: 'YYYYMMDD-HHmmss'
       - uses: jakejarvis/s3-sync-action@master
-        if: github.ref == 'refs/heads/assets-autodeploy' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         with:
           args: --acl public-read --follow-symlinks --delete
         env:
@@ -63,7 +63,7 @@ jobs:
           SOURCE_DIR: 'public'
           DEST_DIR: 'assets-${{ steps.time.outputs.time }}'
       - uses: jakejarvis/s3-sync-action@master
-        if: github.ref == 'refs/heads/assets-autodeploy' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         with:
           args: --acl public-read --follow-symlinks --delete
         env:
@@ -74,13 +74,13 @@ jobs:
           SOURCE_DIR: 'public'
           DEST_DIR: 'assets'
       - run: mkdir assets && mv public assets/ && cp LICENSE COPYING.md README.md assets/ && git log -n 1 --pretty=oneline > assets/commit.txt
-        if: github.ref == 'refs/heads/assets-autodeploy' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
       - run: cd assets && tar -cvpJf ../assets.tar.xz . && cd -
-        if: github.ref == 'refs/heads/assets-autodeploy' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         env:
           XZ_OPT: '-0'
       - uses: actions/upload-artifact@v1
-        if: github.ref == 'refs/heads/assets-autodeploy' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         with:
           name: lila-assets
           path: assets.tar.xz


### PR DESCRIPTION
Does a double sync which isn't the most efficient, but the size is small enough that it isn't really affecting the action time too much

To make sure the main server gets restarted, we could make the server action be dependent on the asset action to make sure it happens first. Currently it kinda works by accident on the fact assets build slightly faster than the main server.