### PR TITLE
New tournament schedule

### DIFF
--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -18,7 +18,7 @@ case class Schedule(
 
   // Simpler naming for now.
   def name(full: Boolean = true)(implicit lang: Lang): String = {
-    s"${variant.name} Mind Sports Olympiad Prep"
+    s"${variant.name} Mind Sports Olympiad Warm-up"
     /*
     import Schedule.Freq._
     import Schedule.Speed._

--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -75,7 +75,7 @@ final private class TournamentScheduler(
 
     val farFuture = today plusMonths 7
 
-    val birthday = new DateTime(2010, 6, 20, 12, 0, 0)
+    val birthday = new DateTime(2021, 7, 29, 12, 0, 0)
 
     val fss = List(nextFriday, nextSaturday, nextSunday)
     val mwfs = List(nextMonday, nextWednesday, nextFriday, nextSunday)


### PR DESCRIPTION
This implements the new tournament schedule. 

I removed all of the old tournaments, which makes these _very_ prominent when they are active, but it's very empty otherwise. It should be easy enough to fill up the rest of the times with a similar rotation if desired, but it's not strictly necessary.

I took the opportunity to rename them to all say: `Mind Sports Olympiad Prep`, not sure if you like that or not. If you don't, feel free to change it.