### PR TITLE
chore: Add diagnostics for duct timeouts and application-wide stalls

### DIFF
--- a/app/Env.scala
+++ b/app/Env.scala
@@ -98,6 +98,20 @@ final class Env(
   val explorerEndpoint  = config.get[String]("explorer.endpoint")
   val tablebaseEndpoint = config.get[String]("explorer.tablebase.endpoint")
 
+  // Measures execution context latency and akka scheduler drift from a dedicated thread, and captures duct
+  // and thread state when either stalls. Set stall.enabled = false to disable.
+  val stallDetector: Option[lila.common.StallDetector] =
+    config
+      .getOptional[Boolean]("stall.enabled")
+      .getOrElse(true)
+      .option(
+        new lila.common.StallDetector(
+          stallThresholdMillis = config.getOptional[Long]("stall.thresholdMillis").getOrElse(1000L),
+          probeIntervalMillis = config.getOptional[Long]("stall.probeIntervalMillis").getOrElse(200L),
+          dumpCooldownMillis = config.getOptional[Long]("stall.dumpCooldownMillis").getOrElse(30000L)
+        )
+      )
+
   val appVersionDate    = config.getOptional[String]("app.version.date")
   val appVersionCommit  = config.getOptional[String]("app.version.commit")
   val appVersionMessage = config.getOptional[String]("app.version.message")

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -83,6 +83,14 @@ app {
   renderer.name = "renderer"
   stage = false
 }
+stall {
+  enabled = true
+  # milliseconds of execution context latency or scheduler drift that counts as a stall
+  thresholdMillis = 1000
+  probeIntervalMillis = 200
+  # minimum gap between captured thread dumps
+  dumpCooldownMillis = 30000
+}
 api {
   token = secret
   influx_event = {

--- a/modules/common/src/main/DuctHealth.scala
+++ b/modules/common/src/main/DuctHealth.scala
@@ -1,22 +1,15 @@
 package lila.common
 
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.{ AtomicInteger, AtomicReferenceArray }
 import scala.jdk.CollectionConverters.*
 import scala.util.control.NonFatal
 
 object DuctHealth {
 
   final private case class Running(name: String, startedAtNanos: Long)
-  final private case class Finished(name: String, waitMillis: Long, runMillis: Long, outcome: String)
-
-  private val recentCapacity = 256
 
   private val queues  = new ConcurrentHashMap[String, () => Int](64)
   private val running = new ConcurrentHashMap[Long, Running](256)
-
-  private val recent      = new AtomicReferenceArray[Finished](recentCapacity)
-  private val recentIndex = new AtomicInteger(0)
 
   def register(name: String, queueSize: () => Int): Unit = {
     if (!name.contains(':')) queues.put(name, queueSize)
@@ -28,13 +21,10 @@ object DuctHealth {
     ()
   }
 
-  def finished(id: Long, name: String, waitMillis: Long, runMillis: Long, outcome: String): Unit = {
+  def finished(id: Long): Unit = {
     running.remove(id)
-    val slot = math.floorMod(recentIndex.getAndIncrement(), recentCapacity)
-    recent.set(slot, Finished(name, waitMillis, runMillis, outcome))
+    ()
   }
-
-  def recentSize: Int = (0 until recentCapacity).count(recent.get(_) != null)
 
   private def safeSize(name: String, size: () => Int): Option[Int] =
     try Some(size())
@@ -67,17 +57,21 @@ object DuctHealth {
   private val minDepth        = 8
 
   private val reporter = new Thread(
-    () =>
-      while (true) {
-        Thread.sleep(intervalMillis)
-        try
+    () => {
+      var keepRunning = true
+      while (keepRunning)
+        try {
+          Thread.sleep(intervalMillis)
           report(System.nanoTime(), minRunMillis, minDepth) foreach { lines =>
             lila.log("duct").info(s"health\n$lines")
           }
-        catch {
+        } catch {
+          case _: InterruptedException =>
+            Thread.currentThread().interrupt()
+            keepRunning = false
           case NonFatal(e) => lila.log("duct").warn("health: reporting pass failed", e)
         }
-      },
+    },
     "lila-duct-health"
   )
   reporter.setDaemon(true)

--- a/modules/common/src/main/DuctHealth.scala
+++ b/modules/common/src/main/DuctHealth.scala
@@ -55,4 +55,21 @@ object DuctHealth {
     val lines = deep ::: stuck
     if (lines.isEmpty) None else Some(lines.mkString("\n"))
   }
+
+  private val intervalMillis  = 10000L
+  private val minRunMillis    = 5000L
+  private val minDepth        = 8
+
+  private val reporter = new Thread(
+    () =>
+      while (true) {
+        Thread.sleep(intervalMillis)
+        report(System.nanoTime(), minRunMillis, minDepth) foreach { lines =>
+          lila.log("duct").info(s"health\n$lines")
+        }
+      },
+    "lila-duct-health"
+  )
+  reporter.setDaemon(true)
+  reporter.start()
 }

--- a/modules/common/src/main/DuctHealth.scala
+++ b/modules/common/src/main/DuctHealth.scala
@@ -1,8 +1,9 @@
 package lila.common
 
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{ AtomicInteger, AtomicReferenceArray }
 import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
 
 object DuctHealth {
 
@@ -14,7 +15,7 @@ object DuctHealth {
   private val queues  = new ConcurrentHashMap[String, () => Int](64)
   private val running = new ConcurrentHashMap[Long, Running](256)
 
-  private val recent      = new Array[Finished](recentCapacity)
+  private val recent      = new AtomicReferenceArray[Finished](recentCapacity)
   private val recentIndex = new AtomicInteger(0)
 
   def register(name: String, queueSize: () => Int): Unit = {
@@ -30,17 +31,22 @@ object DuctHealth {
   def finished(id: Long, name: String, waitMillis: Long, runMillis: Long, outcome: String): Unit = {
     running.remove(id)
     val slot = math.floorMod(recentIndex.getAndIncrement(), recentCapacity)
-    recent.synchronized {
-      recent(slot) = Finished(name, waitMillis, runMillis, outcome)
-    }
-    ()
+    recent.set(slot, Finished(name, waitMillis, runMillis, outcome))
   }
 
-  def recentSize: Int = recent.synchronized(recent.count(_ != null))
+  def recentSize: Int = (0 until recentCapacity).count(recent.get(_) != null)
+
+  private def safeSize(name: String, size: () => Int): Option[Int] =
+    try Some(size())
+    catch {
+      case NonFatal(e) =>
+        lila.log("duct").warn(s"health: $name queue size threw", e)
+        None
+    }
 
   def report(nowNanos: Long, minRunMillis: Long, minDepth: Int): Option[String] = {
     val deep = queues.asScala.toList
-      .map { case (name, size) => name -> size() }
+      .flatMap { case (name, size) => safeSize(name, size).map(name -> _) }
       .filter { case (_, depth) => depth >= minDepth }
       .sortBy { case (_, depth) => -depth }
       .map { case (name, depth) => s"  deep $name depth=$depth" }
@@ -64,8 +70,12 @@ object DuctHealth {
     () =>
       while (true) {
         Thread.sleep(intervalMillis)
-        report(System.nanoTime(), minRunMillis, minDepth) foreach { lines =>
-          lila.log("duct").info(s"health\n$lines")
+        try
+          report(System.nanoTime(), minRunMillis, minDepth) foreach { lines =>
+            lila.log("duct").info(s"health\n$lines")
+          }
+        catch {
+          case NonFatal(e) => lila.log("duct").warn("health: reporting pass failed", e)
         }
       },
     "lila-duct-health"

--- a/modules/common/src/main/DuctHealth.scala
+++ b/modules/common/src/main/DuctHealth.scala
@@ -1,0 +1,58 @@
+package lila.common
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import scala.jdk.CollectionConverters.*
+
+object DuctHealth {
+
+  final private case class Running(name: String, startedAtNanos: Long)
+  final private case class Finished(name: String, waitMillis: Long, runMillis: Long, outcome: String)
+
+  private val recentCapacity = 256
+
+  private val queues  = new ConcurrentHashMap[String, () => Int](64)
+  private val running = new ConcurrentHashMap[Long, Running](256)
+
+  private val recent      = new Array[Finished](recentCapacity)
+  private val recentIndex = new AtomicInteger(0)
+
+  def register(name: String, queueSize: () => Int): Unit = {
+    if (!name.contains(':')) queues.put(name, queueSize)
+    ()
+  }
+
+  def started(id: Long, name: String, startedAtNanos: Long): Unit = {
+    running.put(id, Running(name, startedAtNanos))
+    ()
+  }
+
+  def finished(id: Long, name: String, waitMillis: Long, runMillis: Long, outcome: String): Unit = {
+    running.remove(id)
+    val slot = math.floorMod(recentIndex.getAndIncrement(), recentCapacity)
+    recent.synchronized {
+      recent(slot) = Finished(name, waitMillis, runMillis, outcome)
+    }
+    ()
+  }
+
+  def recentSize: Int = recent.synchronized(recent.count(_ != null))
+
+  def report(nowNanos: Long, minRunMillis: Long, minDepth: Int): Option[String] = {
+    val deep = queues.asScala.toList
+      .map { case (name, size) => name -> size() }
+      .filter { case (_, depth) => depth >= minDepth }
+      .sortBy { case (_, depth) => -depth }
+      .map { case (name, depth) => s"  deep $name depth=$depth" }
+
+    val stuck = running.asScala.values.toList
+      .map(r => r.name -> (nowNanos - r.startedAtNanos) / 1000000)
+      .filter { case (_, ms) => ms >= minRunMillis }
+      .sortBy { case (_, ms) => -ms }
+      .take(20)
+      .map { case (name, ms) => s"  running $name for ${ms}ms" }
+
+    val lines = deep ::: stuck
+    if (lines.isEmpty) None else Some(lines.mkString("\n"))
+  }
+}

--- a/modules/common/src/main/DuctRegistry.scala
+++ b/modules/common/src/main/DuctRegistry.scala
@@ -1,0 +1,71 @@
+package lila.common
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters.*
+
+/** Diagnostic registry of every Duct and DuctSequencer in the JVM.
+  *
+  * Ducts are the serialisation points of the application: each one runs at most one task at a time, so a
+  * single slow or wedged task stalls everything queued behind it. The registry records, for each duct, how
+  * deep its queue is and which task (if any) is currently running, so that a stall can be attributed to a
+  * specific duct rather than inferred from a scattering of timeout logs.
+  *
+  * Registration is by name. DuctSequencer names are unique by construction; DuctConcMap-backed ducts (round
+  * games, study chapters) share a single registry entry per map, reporting aggregate depth.
+  */
+object DuctRegistry {
+
+  final private case class Running(id: Long, startedAtNanos: Long, label: String)
+
+  final private class Entry(val queueSize: () => Int) {
+    val running = new ConcurrentHashMap[Long, Running](4)
+  }
+
+  private val entries = new ConcurrentHashMap[String, Entry](256)
+
+  def register(name: String, queueSize: () => Int): Unit = {
+    entries.put(name, new Entry(queueSize))
+    ()
+  }
+
+  def started(name: String, id: Long, startedAtNanos: Long, label: String): Unit = {
+    Option(entries.get(name)).foreach(_.running.put(id, Running(id, startedAtNanos, label)))
+    ()
+  }
+
+  def finished(name: String, id: Long): Unit = {
+    Option(entries.get(name)).foreach(_.running.remove(id))
+    ()
+  }
+
+  /** Names and depths only, cheap enough to sample on a timer. */
+  def depths: List[(String, Int)] =
+    entries.asScala.toList.map { case (name, entry) => name -> entry.queueSize() }
+
+  /** Human readable snapshot for stall logs. Only reports ducts that are busy or backed up, so the output
+    * stays readable when a few hundred ducts are registered.
+    */
+  def dump(nowNanos: Long = System.nanoTime()): String = {
+    val lines = entries.asScala.toList
+      .flatMap { case (name, entry) =>
+        val depth   = entry.queueSize()
+        val running = entry.running.values.asScala.toList
+        if (depth <= 0 && running.isEmpty) None
+        else {
+          val runningStr =
+            if (running.isEmpty) "idle"
+            else
+              running
+                .sortBy(_.startedAtNanos)
+                .map(r => s"#${r.id}[${r.label}] for ${(nowNanos - r.startedAtNanos) / 1000000}ms")
+                .mkString(", ")
+          val oldest = running.map(r => (nowNanos - r.startedAtNanos) / 1000000).maxOption.getOrElse(0L)
+          Some((oldest, depth, s"  $name depth=$depth $runningStr"))
+        }
+      }
+      .sortBy { case (oldest, depth, _) => (-oldest, -depth) }
+      .map(_._3)
+    if (lines.isEmpty) "  (all ducts idle and empty)"
+    else lines.take(40).mkString("\n")
+  }
+}

--- a/modules/common/src/main/StallDetector.scala
+++ b/modules/common/src/main/StallDetector.scala
@@ -1,0 +1,157 @@
+package lila.common
+
+import java.lang.management.ManagementFactory
+import java.util.concurrent.{ ArrayBlockingQueue, Executors, TimeUnit }
+import java.util.concurrent.atomic.AtomicLong
+import scala.concurrent.ExecutionContext
+
+/** Detects and characterises application-wide stalls.
+  *
+  * The application has two independent scarce resources that can each stall everything: the default
+  * execution context (a bounded fork-join pool shared by HTTP handling, Mongo callbacks, ducts and akka
+  * streams) and the akka scheduler, which drives every periodic actor and every future timeout. When those
+  * stall, the resulting logs are indistinguishable: DuctSequencer timeouts and actor ReceiveTimeouts fire
+  * together regardless of the cause.
+  *
+  * This runs two probes on a dedicated thread, outside both resources, so it keeps measuring while they are
+  * saturated:
+  *
+  *   - execution context latency: how long a trivial task waits before the pool runs it. High means no free
+  *     pool threads, i.e. threads are blocked or saturated.
+  *   - scheduler drift: how late the akka scheduler fires a short timer, with its callback delivered on a
+  *     private thread so a saturated pool cannot contaminate the reading. High means the scheduler itself is
+  *     behind, which makes periodic actors miss heartbeats even when the work they do is fast.
+  *
+  * The two readings together identify the failure mode:
+  *
+  *   - context latency high, drift low: pool exhaustion. The captured thread dump names the culprit.
+  *   - both high: the whole JVM is descheduled. Check GC and safepoint logs.
+  *   - both low while timeouts still fire: the work itself is genuinely waiting, most likely on I/O, and the
+  *     concurrency layer is not at fault.
+  *
+  * On a stall it captures duct state and a thread dump, summarised by top stack frame so that many threads
+  * parked in one place are obvious at a glance.
+  */
+final class StallDetector(
+    stallThresholdMillis: Long = 1000,
+    probeIntervalMillis: Long = 200,
+    dumpCooldownMillis: Long = 30000,
+    probeTimeoutMillis: Long = 15000
+)(implicit ec: ExecutionContext, scheduler: akka.actor.Scheduler) {
+
+  private val logger = lila.log("stall")
+
+  // The scheduler probe's callback must not run on the pool we are also measuring, otherwise a saturated
+  // pool would show up as scheduler drift and the two readings would stop being independent.
+  private val schedulerCallbackEc: ExecutionContext =
+    ExecutionContext.fromExecutorService(
+      Executors.newSingleThreadExecutor { r =>
+        val t = new Thread(r, "lila-stall-scheduler-probe")
+        t.setDaemon(true)
+        t
+      }
+    )
+
+  private val lastDumpAt = new AtomicLong(0)
+
+  private val thread = new Thread(() => probeLoop(), "lila-stall-detector")
+  thread.setDaemon(true)
+  thread.start()
+
+  logger.info(
+    s"stall detector started, threshold=${stallThresholdMillis}ms interval=${probeIntervalMillis}ms"
+  )
+
+  private def probeLoop(): Unit =
+    while (true) {
+      val contextLatency = probeExecutionContext()
+      val drift          = probeScheduler()
+
+      lila.mon.stall.contextLatency.record(contextLatency)
+      lila.mon.stall.schedulerDrift.record(drift)
+
+      if (contextLatency > stallThresholdMillis || drift > stallThresholdMillis)
+        onStall(contextLatency, drift)
+
+      Thread.sleep(probeIntervalMillis)
+    }
+
+  /** Milliseconds between submitting a no-op task and the pool running it. */
+  private def probeExecutionContext(): Long = {
+    val handoff = new ArrayBlockingQueue[java.lang.Long](1)
+    val startedAt = System.nanoTime()
+    ec.execute { () =>
+      handoff.offer(java.lang.Long.valueOf((System.nanoTime() - startedAt) / 1000000))
+      ()
+    }
+    Option(handoff.poll(probeTimeoutMillis, TimeUnit.MILLISECONDS))
+      .fold(probeTimeoutMillis)(_.longValue)
+  }
+
+  /** Milliseconds by which the akka scheduler overshoots a 100ms timer. */
+  private def probeScheduler(): Long = {
+    val handoff   = new ArrayBlockingQueue[java.lang.Long](1)
+    val startedAt = System.nanoTime()
+    scheduler.scheduleOnce(100.millis) {
+      handoff.offer(java.lang.Long.valueOf(((System.nanoTime() - startedAt) / 1000000) - 100))
+      ()
+    }(using schedulerCallbackEc)
+    Option(handoff.poll(probeTimeoutMillis, TimeUnit.MILLISECONDS))
+      .fold(probeTimeoutMillis)(_.longValue)
+  }
+
+  private def onStall(contextLatency: Long, drift: Long): Unit = {
+    lila.mon.stall.detected.increment()
+    val now = System.currentTimeMillis()
+    if (now - lastDumpAt.get() >= dumpCooldownMillis) {
+      lastDumpAt.set(now)
+      logger.warn(
+        s"STALL contextLatency=${contextLatency}ms schedulerDrift=${drift}ms\n" +
+          s"ducts:\n${DuctRegistry.dump()}\n" +
+          s"threads:\n${threadReport()}"
+      )
+    }
+  }
+
+  private def threadReport(): String = {
+    val infos = ManagementFactory.getThreadMXBean.dumpAllThreads(false, false).toList
+
+    val byState = infos
+      .groupBy(_.getThreadState)
+      .view
+      .mapValues(_.size)
+      .toList
+      .sortBy(-_._2)
+      .map { case (state, n) => s"$state=$n" }
+      .mkString(" ")
+
+    // Many threads sharing a top frame is the signature of a common block: a lock, a blocking await, or a
+    // saturated I/O pool. This histogram surfaces it without needing to read every stack.
+    val hotFrames = infos
+      .flatMap(_.getStackTrace.headOption.map(_.toString))
+      .groupBy(identity)
+      .view
+      .mapValues(_.size)
+      .toList
+      .sortBy(-_._2)
+      .take(10)
+      .map { case (frame, n) => s"    ${n}x $frame" }
+      .mkString("\n")
+
+    val interesting = infos
+      .filter { t =>
+        val name = t.getThreadName
+        name.contains("dispatcher") || name.contains("lila") || name.contains("reactivemongo")
+      }
+      .sortBy(_.getThreadName)
+      .map { t =>
+        val lock  = Option(t.getLockName).fold("")(l => s" blockedOn=$l")
+        val owner = Option(t.getLockOwnerName).fold("")(o => s" lockOwner=$o")
+        val stack = t.getStackTrace.take(15).map(f => s"      at $f").mkString("\n")
+        s"  ${t.getThreadName} ${t.getThreadState}$lock$owner\n$stack"
+      }
+      .mkString("\n")
+
+    s"  states: $byState\n  hottest frames:\n$hotFrames\n$interesting"
+  }
+}

--- a/modules/common/src/main/mon.scala
+++ b/modules/common/src/main/mon.scala
@@ -206,6 +206,23 @@ object mon {
   }
   object duct {
     def overflow(name: String) = counter("duct.overflow").withTag("name", name)
+    // milliseconds a task spent queued before the duct started running it
+    def queueWait(name: String) = histogram("duct.queue.wait").withTag("name", name)
+    // milliseconds a task took once started, measured on the real future rather than the timeout race
+    def runTime(name: String) = histogram("duct.run.time").withTag("name", name)
+    def timeout(name: String) = counter("duct.timeout").withTag("name", name)
+    // tasks that outlived their own timeout; a rate below duct.timeout means tasks are vanishing entirely
+    def lateCompletion(name: String) = histogram("duct.late.completion").withTag("name", name)
+    // a duct's process function threw synchronously, which would have deadlocked it permanently
+    def wedged(name: String) = counter("duct.wedged").withTag("name", name)
+    def depth(name: String)  = histogram("duct.depth").withTag("name", name)
+  }
+  object stall {
+    // milliseconds between submitting a no-op task and the default execution context running it
+    val contextLatency = histogram("stall.context.latency").withoutTags()
+    // milliseconds by which the akka scheduler overshot a short timer
+    val schedulerDrift = histogram("stall.scheduler.drift").withoutTags()
+    val detected       = counter("stall.detected").withoutTags()
   }
   object user {
     val online = gauge("user.online").withoutTags()

--- a/modules/common/src/test/DuctHealthTest.scala
+++ b/modules/common/src/test/DuctHealthTest.scala
@@ -31,6 +31,6 @@ class DuctHealthTest extends munit.FunSuite {
     (1 to 1000).foreach { i =>
       DuctHealth.finished(i.toLong, s"n$i", 0L, 1L, "success")
     }
-    assert(DuctHealth.recentSize <= 256, DuctHealth.recentSize)
+    assertEquals(DuctHealth.recentSize, 256)
   }
 }

--- a/modules/common/src/test/DuctHealthTest.scala
+++ b/modules/common/src/test/DuctHealthTest.scala
@@ -1,0 +1,36 @@
+package lila.common
+
+class DuctHealthTest extends munit.FunSuite {
+
+  test("ignore per-key duct names in the registry") {
+    DuctHealth.register("tournament:abc123", () => 99)
+    assertEquals(DuctHealth.report(0L, 1L, 1), None)
+  }
+
+  test("report a duct whose queue is deep enough") {
+    DuctHealth.register("fishnetApi", () => 12)
+    val out = DuctHealth.report(0L, Long.MaxValue, 8)
+    assert(out.exists(_.contains("fishnetApi")), out)
+    DuctHealth.register("fishnetApi", () => 0)
+  }
+
+  test("report a task running longer than the bar") {
+    DuctHealth.started(1L, "slowOne", 0L)
+    val out = DuctHealth.report(5000000000L, 1000L, Int.MaxValue)
+    assert(out.exists(_.contains("slowOne")), out)
+    DuctHealth.finished(1L, "slowOne", 0L, 5000L, "success")
+  }
+
+  test("forget a task once it finishes") {
+    DuctHealth.started(2L, "quickOne", 0L)
+    DuctHealth.finished(2L, "quickOne", 0L, 1L, "success")
+    assertEquals(DuctHealth.report(5000000000L, 1000L, Int.MaxValue), None)
+  }
+
+  test("bound the recent completions buffer") {
+    (1 to 1000).foreach { i =>
+      DuctHealth.finished(i.toLong, s"n$i", 0L, 1L, "success")
+    }
+    assert(DuctHealth.recentSize <= 256, DuctHealth.recentSize)
+  }
+}

--- a/modules/common/src/test/DuctHealthTest.scala
+++ b/modules/common/src/test/DuctHealthTest.scala
@@ -18,19 +18,12 @@ class DuctHealthTest extends munit.FunSuite {
     DuctHealth.started(1L, "slowOne", 0L)
     val out = DuctHealth.report(5000000000L, 1000L, Int.MaxValue)
     assert(out.exists(_.contains("slowOne")), out)
-    DuctHealth.finished(1L, "slowOne", 0L, 5000L, "success")
+    DuctHealth.finished(1L)
   }
 
   test("forget a task once it finishes") {
     DuctHealth.started(2L, "quickOne", 0L)
-    DuctHealth.finished(2L, "quickOne", 0L, 1L, "success")
+    DuctHealth.finished(2L)
     assertEquals(DuctHealth.report(5000000000L, 1000L, Int.MaxValue), None)
-  }
-
-  test("bound the recent completions buffer") {
-    (1 to 1000).foreach { i =>
-      DuctHealth.finished(i.toLong, s"n$i", 0L, 1L, "success")
-    }
-    assertEquals(DuctHealth.recentSize, 256)
   }
 }

--- a/modules/fishnet/src/main/FishnetApi.scala
+++ b/modules/fishnet/src/main/FishnetApi.scala
@@ -68,6 +68,7 @@ final class FishnetApi(
         s"allowedLogics=${allowedLogicIds.toList.sorted.mkString(",")} slow=$slow"
     )
     workQueue {
+      val startedAt = System.nanoTime()
       analysisColl
         .find(
           $doc("acquired".$exists(false)) ++ {
@@ -83,13 +84,22 @@ final class FishnetApi(
           )
         )
         .one[Work.Analysis]
-        .flatMap {
-          _ so { work =>
+        .flatMap { found =>
+          val foundAt = System.nanoTime()
+          val assigned = found so { work =>
             logger.info(
               s"assign ${work.id} variant=${work.game.variant.key}(gl=${work.game.variant.gameLogic.id}) " +
                 s"to ${client.fullId}"
             )
             repo.updateAnalysis(work.assignTo(client)) inject work.some
+          }
+          assigned.addEffectAnyway {
+            val doneAt   = System.nanoTime()
+            val findMs   = (foundAt - startedAt) / 1000000
+            val updateMs = (doneAt - foundAt) / 1000000
+            val totalMs  = (doneAt - startedAt) / 1000000
+            if (totalMs > 1000)
+              logger.info(s"acquire slow find=${findMs}ms update=${updateMs}ms total=${totalMs}ms")
           }
         }
     }.map { _ map JsonApi.analysisFromWork(config.analysisNodes) }

--- a/modules/fishnet/src/main/FishnetApi.scala
+++ b/modules/fishnet/src/main/FishnetApi.scala
@@ -99,7 +99,7 @@ final class FishnetApi(
             val updateMs = (doneAt - foundAt) / 1000000
             val totalMs  = (doneAt - startedAt) / 1000000
             if (totalMs > 1000)
-              logger.info(s"acquire slow find=${findMs}ms update=${updateMs}ms total=${totalMs}ms")
+              logger.info(s"acquire slow find=${findMs}ms update=${updateMs}ms")
           }
         }
     }.map { _ map JsonApi.analysisFromWork(config.analysisNodes) }

--- a/modules/hub/src/main/BoundedDuct.scala
+++ b/modules/hub/src/main/BoundedDuct.scala
@@ -52,8 +52,25 @@ final class BoundedDuct(maxSize: Int, name: String, logging: Boolean = true)(pro
    */
   private val stateRef: AtomicReference[State] = new AtomicReference(None)
 
+  /* `process` is expected to return a future; if it instead throws synchronously, the state ref is left
+   * marked busy and this duct never runs another task for the lifetime of the JVM. Callers then see their
+   * futures hang rather than fail, which is close to invisible in the logs. Draining the queue anyway keeps
+   * the duct alive and makes the event loud. The exception is still rethrown so that callers observe exactly
+   * what they observe today.
+   */
   private def run(msg: Any): Unit =
-    process.applyOrElse(msg, fallback).onComplete(postRun)
+    try process.applyOrElse(msg, fallback).onComplete(postRun)
+    catch {
+      case e: Throwable =>
+        lila.mon.duct.wedged(name).increment()
+        lila.log("duct").error(
+          s"[$name] process threw synchronously on ${msg.getClass.getSimpleName}; " +
+            "duct would have wedged permanently, draining queue instead",
+          e
+        )
+        postRun(())
+        throw e
+    }
 
   private val postRun = (_: Any) => stateRef.getAndUpdate(postRunUpdate).flatMap(_.headOption).foreach(run)
 

--- a/modules/hub/src/main/Duct.scala
+++ b/modules/hub/src/main/Duct.scala
@@ -33,8 +33,26 @@ abstract class Duct(implicit ec: scala.concurrent.ExecutionContext) extends lila
    */
   private val stateRef: AtomicReference[State] = new AtomicReference(None)
 
+  /* Number of messages this duct still has to process, including the one in flight. Unbounded ducts have no
+   * backpressure and no overflow counter, so without this a backlog is entirely invisible.
+   */
+  def queueSize: Int = stateRef.get().fold(0)(_.size + 1)
+
+  // See the equivalent guard in BoundedDuct: a synchronous throw from `process` would otherwise wedge this
+  // duct permanently, silently hanging every future that depends on it.
   private def run(msg: Any): Unit =
-    process.applyOrElse(msg, Duct.fallback).onComplete(postRun)
+    try process.applyOrElse(msg, Duct.fallback).onComplete(postRun)
+    catch {
+      case e: Throwable =>
+        lila.mon.duct.wedged("unbounded").increment()
+        lila.log("duct").error(
+          s"process threw synchronously on ${msg.getClass.getSimpleName}; " +
+            "duct would have wedged permanently, draining queue instead",
+          e
+        )
+        postRun(())
+        throw e
+    }
 
   private val postRun = (_: Any) => stateRef.getAndUpdate(postRunUpdate).flatMap(_.headOption).foreach(run)
 }

--- a/modules/hub/src/main/Duct.scala
+++ b/modules/hub/src/main/Duct.scala
@@ -33,6 +33,8 @@ abstract class Duct(implicit ec: scala.concurrent.ExecutionContext) extends lila
    */
   private val stateRef: AtomicReference[State] = new AtomicReference(None)
 
+  def queueSize: Int = stateRef.get().fold(0)(_.size + 1)
+
   private def run(msg: Any): Unit =
     process.applyOrElse(msg, Duct.fallback).onComplete(postRun)
 

--- a/modules/hub/src/main/DuctConcMap.scala
+++ b/modules/hub/src/main/DuctConcMap.scala
@@ -38,6 +38,10 @@ final class DuctConcMap[D <: Duct](
   def foreachKey(f: String => Unit): Unit =
     ducts.forEachKey(16, k => f(k))
 
+  // sequential on the calling thread, unlike tellAll, so callers may accumulate into local state
+  def foreachValue(f: D => Unit): Unit =
+    ducts.forEachValue(Long.MaxValue, d => f(d))
+
   def tellAllWithAck(makeMsg: Promise[Unit] => Any)(implicit ec: ExecutionContext): Fu[Int] =
     Future
       .sequence(ducts.values.asScala.map(_.ask(makeMsg)))

--- a/modules/hub/src/main/DuctConcMap.scala
+++ b/modules/hub/src/main/DuctConcMap.scala
@@ -38,6 +38,9 @@ final class DuctConcMap[D <: Duct](
   def foreachKey(f: String => Unit): Unit =
     ducts.forEachKey(16, k => f(k))
 
+  def foreachValue(f: D => Unit): Unit =
+    ducts.forEachValue(Long.MaxValue, d => f(d))
+
   def tellAllWithAck(makeMsg: Promise[Unit] => Any)(implicit ec: ExecutionContext): Fu[Int] =
     Future
       .sequence(ducts.values.asScala.map(_.ask(makeMsg)))

--- a/modules/hub/src/main/DuctSequencer.scala
+++ b/modules/hub/src/main/DuctSequencer.scala
@@ -1,10 +1,13 @@
 package lila.hub
 
 import com.github.blemale.scaffeine.LoadingCache
+import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Promise
+import scala.util.{ Failure, Success }
 
 import lila.base.LilaTimeout
+import lila.common.DuctRegistry
 
 final class DuctSequencer(maxSize: Int, timeout: FiniteDuration, name: String, logging: Boolean = true)(
     implicit
@@ -14,26 +17,64 @@ final class DuctSequencer(maxSize: Int, timeout: FiniteDuration, name: String, l
 
   import DuctSequencer.*
 
+  private val nextId = new AtomicLong(0)
+
   def apply[A](fu: => Fu[A]): Fu[A] = run(() => fu)
 
-  def run[A](task: Task[A]): Fu[A] = duct.ask[A](TaskWithPromise(task, _))
+  def run[A](task: Task[A]): Fu[A] =
+    duct.ask[A](TaskWithPromise(task, _, nextId.incrementAndGet(), System.nanoTime(), duct.queueSize))
 
-  private val duct = new BoundedDuct(maxSize, name, logging)({ case TaskWithPromise(task, promise) =>
-    promise.completeWith {
-      task()
-        .withTimeout(timeout, s"$name DuctSequencer")
-        .transform(
-          identity,
-          {
-            case LilaTimeout(msg) =>
-              val fullMsg = s"$name DuctSequencer $msg"
-              if (logging) lila.log("duct").warn(fullMsg)
-              LilaTimeout(fullMsg)
-            case e => e
+  // explicit type: the process closure below reads `duct.queueSize`, so inference would be cyclic
+  private val duct: BoundedDuct = new BoundedDuct(maxSize, name, logging)({
+    case TaskWithPromise(task, promise, id, enqueuedAtNanos, depthAtEnqueue) =>
+      val startedAtNanos = System.nanoTime()
+      val waitMillis     = (startedAtNanos - enqueuedAtNanos) / 1000000
+      DuctRegistry.started(name, id, startedAtNanos, "task")
+      lila.mon.duct.queueWait(name).record(waitMillis)
+
+      val real = task()
+
+      // The timeout below abandons `real` rather than cancelling it, so without this observer a timed out
+      // task leaves no trace of what became of it. Distinguishing "finished just over the limit" from
+      // "finished a minute later" from "never finished at all" is the whole point of this instrumentation:
+      // only the last of those three indicates a lost callback or an unfulfilled promise.
+      real.onComplete { result =>
+        val runMillis = (System.nanoTime() - startedAtNanos) / 1000000
+        DuctRegistry.finished(name, id)
+        lila.mon.duct.runTime(name).record(runMillis)
+        if (runMillis > timeout.toMillis) {
+          lila.mon.duct.lateCompletion(name).record(runMillis)
+          val outcome = result match {
+            case Success(_) => "success"
+            case Failure(e) => s"failure:${e.getClass.getSimpleName}"
           }
-        )
-    }.future
+          lila.log("duct").warn(
+            s"[$name#$id] completed AFTER its ${timeout.toMillis}ms timeout: " +
+              s"wait=${waitMillis}ms run=${runMillis}ms depthAtEnqueue=$depthAtEnqueue outcome=$outcome"
+          )
+        }
+      }
+
+      promise.completeWith {
+        real
+          .withTimeout(timeout, s"$name DuctSequencer")
+          .transform(
+            identity,
+            {
+              case LilaTimeout(msg) =>
+                lila.mon.duct.timeout(name).increment()
+                val fullMsg =
+                  s"$name DuctSequencer $msg [id=$id wait=${waitMillis}ms " +
+                    s"depthAtEnqueue=$depthAtEnqueue depthNow=${duct.queueSize}]"
+                if (logging) lila.log("duct").warn(fullMsg)
+                LilaTimeout(fullMsg)
+              case e => e
+            }
+          )
+      }.future
   })
+
+  DuctRegistry.register(name, () => duct.queueSize)
 }
 
 // Distributes tasks to many sequencers
@@ -62,5 +103,11 @@ final class DuctSequencers(
 object DuctSequencer {
 
   private type Task[A] = () => Fu[A]
-  private case class TaskWithPromise[A](task: Task[A], promise: Promise[A])
+  private case class TaskWithPromise[A](
+      task: Task[A],
+      promise: Promise[A],
+      id: Long,
+      enqueuedAtNanos: Long,
+      depthAtEnqueue: Int
+  )
 }

--- a/modules/hub/src/main/DuctSequencer.scala
+++ b/modules/hub/src/main/DuctSequencer.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Promise
 import scala.util.{ Failure, Success }
+import scala.util.control.NonFatal
 
 import lila.base.LilaTimeout
 import lila.common.DuctHealth
@@ -19,7 +20,7 @@ final class DuctSequencer(maxSize: Int, timeout: FiniteDuration, name: String, l
 
   def apply[A](fu: => Fu[A]): Fu[A] = run(() => fu)
 
-  private val nextId = new AtomicLong(0)
+  private val lastLateWarnNanos = new AtomicLong(0)
 
   def run[A](task: Task[A]): Fu[A] =
     duct.ask[A](TaskWithPromise(task, _, nextId.incrementAndGet(), System.nanoTime(), duct.queueSize))
@@ -31,22 +32,35 @@ final class DuctSequencer(maxSize: Int, timeout: FiniteDuration, name: String, l
 
       DuctHealth.started(id, name, startedAtNanos)
 
-      val real = task()
+      val real =
+        try task()
+        catch {
+          case NonFatal(e) =>
+            DuctHealth.finished(id)
+            throw e
+        }
 
       real.onComplete { result =>
+        DuctHealth.finished(id)
         val runMillis = (System.nanoTime() - startedAtNanos) / 1000000
-        DuctHealth.finished(id, name, waitMillis, runMillis, "done")
-        if (runMillis > timeout.toMillis) {
-          val outcome = result match {
-            case Success(_) => "success"
-            case Failure(e) => s"failure:${e.getClass.getSimpleName}"
+        if (logging && runMillis > timeout.toMillis) {
+          val nowNanos  = System.nanoTime()
+          val lastNanos = lastLateWarnNanos.get()
+          if (
+            nowNanos - lastNanos >= lateWarnIntervalNanos &&
+            lastLateWarnNanos.compareAndSet(lastNanos, nowNanos)
+          ) {
+            val outcome = result match {
+              case Success(_) => "success"
+              case Failure(e) => s"failure:${e.getClass.getSimpleName}"
+            }
+            lila.log("duct").warn(
+              s"[$name#$id] completed AFTER its ${timeout.toMillis}ms timeout: " +
+                s"wait=${waitMillis}ms run=${runMillis}ms depthAtEnqueue=$depthAtEnqueue outcome=$outcome"
+            )
           }
-          lila.log("duct").warn(
-            s"[$name#$id] completed AFTER its ${timeout.toMillis}ms timeout: " +
-              s"wait=${waitMillis}ms run=${runMillis}ms depthAtEnqueue=$depthAtEnqueue outcome=$outcome"
-          )
         }
-      }
+      }(using scala.concurrent.ExecutionContext.parasitic)
 
       promise.completeWith {
         real
@@ -93,6 +107,10 @@ final class DuctSequencers(
 }
 
 object DuctSequencer {
+
+  private val nextId = new AtomicLong(0)
+
+  private val lateWarnIntervalNanos = 1000000000L
 
   private type Task[A] = () => Fu[A]
   private case class TaskWithPromise[A](

--- a/modules/hub/src/main/DuctSequencer.scala
+++ b/modules/hub/src/main/DuctSequencer.scala
@@ -7,6 +7,7 @@ import scala.concurrent.Promise
 import scala.util.{ Failure, Success }
 
 import lila.base.LilaTimeout
+import lila.common.DuctHealth
 
 final class DuctSequencer(maxSize: Int, timeout: FiniteDuration, name: String, logging: Boolean = true)(
     implicit
@@ -28,10 +29,13 @@ final class DuctSequencer(maxSize: Int, timeout: FiniteDuration, name: String, l
       val startedAtNanos = System.nanoTime()
       val waitMillis     = (startedAtNanos - enqueuedAtNanos) / 1000000
 
+      DuctHealth.started(id, name, startedAtNanos)
+
       val real = task()
 
       real.onComplete { result =>
         val runMillis = (System.nanoTime() - startedAtNanos) / 1000000
+        DuctHealth.finished(id, name, waitMillis, runMillis, "done")
         if (runMillis > timeout.toMillis) {
           val outcome = result match {
             case Success(_) => "success"
@@ -61,6 +65,8 @@ final class DuctSequencer(maxSize: Int, timeout: FiniteDuration, name: String, l
           )
       }.future
   })
+
+  DuctHealth.register(name, () => duct.queueSize)
 }
 
 // Distributes tasks to many sequencers

--- a/modules/hub/src/main/DuctSequencer.scala
+++ b/modules/hub/src/main/DuctSequencer.scala
@@ -1,6 +1,7 @@
 package lila.hub
 
 import com.github.blemale.scaffeine.LoadingCache
+import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Promise
 
@@ -16,23 +17,31 @@ final class DuctSequencer(maxSize: Int, timeout: FiniteDuration, name: String, l
 
   def apply[A](fu: => Fu[A]): Fu[A] = run(() => fu)
 
-  def run[A](task: Task[A]): Fu[A] = duct.ask[A](TaskWithPromise(task, _))
+  private val nextId = new AtomicLong(0)
 
-  private val duct = new BoundedDuct(maxSize, name, logging)({ case TaskWithPromise(task, promise) =>
-    promise.completeWith {
-      task()
-        .withTimeout(timeout, s"$name DuctSequencer")
-        .transform(
-          identity,
-          {
-            case LilaTimeout(msg) =>
-              val fullMsg = s"$name DuctSequencer $msg"
-              if (logging) lila.log("duct").warn(fullMsg)
-              LilaTimeout(fullMsg)
-            case e => e
-          }
-        )
-    }.future
+  def run[A](task: Task[A]): Fu[A] =
+    duct.ask[A](TaskWithPromise(task, _, nextId.incrementAndGet(), System.nanoTime(), duct.queueSize))
+
+  private val duct: BoundedDuct = new BoundedDuct(maxSize, name, logging)({
+    case TaskWithPromise(task, promise, id, enqueuedAtNanos, depthAtEnqueue) =>
+      val startedAtNanos = System.nanoTime()
+      val waitMillis     = (startedAtNanos - enqueuedAtNanos) / 1000000
+      promise.completeWith {
+        task()
+          .withTimeout(timeout, s"$name DuctSequencer")
+          .transform(
+            identity,
+            {
+              case LilaTimeout(msg) =>
+                val fullMsg =
+                  s"$name DuctSequencer $msg [id=$id wait=${waitMillis}ms " +
+                    s"depthAtEnqueue=$depthAtEnqueue depthNow=${duct.queueSize}]"
+                if (logging) lila.log("duct").warn(fullMsg)
+                LilaTimeout(fullMsg)
+              case e => e
+            }
+          )
+      }.future
   })
 }
 
@@ -62,5 +71,11 @@ final class DuctSequencers(
 object DuctSequencer {
 
   private type Task[A] = () => Fu[A]
-  private case class TaskWithPromise[A](task: Task[A], promise: Promise[A])
+  private case class TaskWithPromise[A](
+      task: Task[A],
+      promise: Promise[A],
+      id: Long,
+      enqueuedAtNanos: Long,
+      depthAtEnqueue: Int
+  )
 }

--- a/modules/hub/src/main/DuctSequencer.scala
+++ b/modules/hub/src/main/DuctSequencer.scala
@@ -4,6 +4,7 @@ import com.github.blemale.scaffeine.LoadingCache
 import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Promise
+import scala.util.{ Failure, Success }
 
 import lila.base.LilaTimeout
 
@@ -26,8 +27,25 @@ final class DuctSequencer(maxSize: Int, timeout: FiniteDuration, name: String, l
     case TaskWithPromise(task, promise, id, enqueuedAtNanos, depthAtEnqueue) =>
       val startedAtNanos = System.nanoTime()
       val waitMillis     = (startedAtNanos - enqueuedAtNanos) / 1000000
+
+      val real = task()
+
+      real.onComplete { result =>
+        val runMillis = (System.nanoTime() - startedAtNanos) / 1000000
+        if (runMillis > timeout.toMillis) {
+          val outcome = result match {
+            case Success(_) => "success"
+            case Failure(e) => s"failure:${e.getClass.getSimpleName}"
+          }
+          lila.log("duct").warn(
+            s"[$name#$id] completed AFTER its ${timeout.toMillis}ms timeout: " +
+              s"wait=${waitMillis}ms run=${runMillis}ms depthAtEnqueue=$depthAtEnqueue outcome=$outcome"
+          )
+        }
+      }
+
       promise.completeWith {
-        task()
+        real
           .withTimeout(timeout, s"$name DuctSequencer")
           .transform(
             identity,

--- a/modules/relay/src/main/RelayFetch.scala
+++ b/modules/relay/src/main/RelayFetch.scala
@@ -48,15 +48,31 @@ final private class RelayFetch(
     { val _ = context.system.scheduler.scheduleOnce(500 millis, self, Tick) }
   }
 
+  /* Self-clocking actor: the next Tick is only scheduled once the current one finishes. A ReceiveTimeout
+   * therefore means either the previous tick never completed, or it did and the scheduled Tick was never
+   * delivered. Note also that `api.toSync` failing skips scheduleNext entirely, which is a third way to get
+   * here; pending will read true in that case, with the elapsed time telling you it stopped early.
+   */
+  @volatile private var tickId        = 0L
+  @volatile private var tickStartedAt = 0L
+  @volatile private var tickPending   = false
+
   def receive = {
 
     case ReceiveTimeout =>
-      val msg = "RelaySync timed out!"
-      logger.error(msg)
+      val stuckForMillis = if (tickPending) (System.nanoTime() - tickStartedAt) / 1000000 else -1L
+      val msg            = "RelaySync timed out!"
+      logger.error(
+        s"$msg tick=$tickId pending=$tickPending stuckFor=${stuckForMillis}ms\n" +
+          s"ducts:\n${lila.common.DuctRegistry.dump()}"
+      )
       lila.mon.relay.timeout.increment()
       throw new RuntimeException(msg)
 
     case Tick =>
+      tickId += 1
+      tickStartedAt = System.nanoTime()
+      tickPending = true
       api.toSync.flatMap { relays =>
         List(true, false) foreach { official =>
           lila.mon.relay.ongoing(official).update(relays.count(_.tour.official == official))
@@ -75,7 +91,10 @@ final private class RelayFetch(
               api.update(rt.round)(_.finish)
             } else fuccess(rt.round)
           })
-          .addEffectAnyway(scheduleNext())
+          .addEffectAnyway {
+            tickPending = false
+            scheduleNext()
+          }
       }.discard
   }
 

--- a/modules/relay/src/main/RelayFetch.scala
+++ b/modules/relay/src/main/RelayFetch.scala
@@ -49,15 +49,23 @@ final private class RelayFetch(
     { val _ = context.system.scheduler.scheduleOnce(500 millis, self, Tick) }
   }
 
+  @volatile private var tickId        = 0L
+  @volatile private var tickStartedAt = 0L
+  @volatile private var tickPending   = false
+
   def receive = {
 
     case ReceiveTimeout =>
-      val msg = "RelaySync timed out!"
-      logger.error(msg)
+      val stuckForMillis = if (tickPending) (System.nanoTime() - tickStartedAt) / 1000000 else -1L
+      val msg            = "RelaySync timed out!"
+      logger.error(s"$msg tick=$tickId pending=$tickPending stuckFor=${stuckForMillis}ms")
       lila.mon.relay.timeout.increment()
       throw new RuntimeException(msg)
 
     case Tick =>
+      tickId += 1
+      tickStartedAt = System.nanoTime()
+      tickPending = true
       api.toSync.flatMap { relays =>
         List(true, false) foreach { official =>
           lila.mon.relay.ongoing(official).update(relays.count(_.tour.official == official))
@@ -76,7 +84,10 @@ final private class RelayFetch(
               api.update(rt.round)(_.finish)
             } else fuccess(rt.round)
           })
-          .addEffectAnyway(scheduleNext())
+          .addEffectAnyway {
+            tickPending = false
+            scheduleNext()
+          }
       }.discard
   }
 

--- a/modules/round/src/main/RoundDuct.scala
+++ b/modules/round/src/main/RoundDuct.scala
@@ -616,9 +616,11 @@ final private[round] class RoundDuct(
     case e: Exception =>
       val sw = new StringWriter
       e.printStackTrace(new PrintWriter(sw))
+      // The stack trace of the actual error is already in the message above. Thread.dumpStack additionally
+      // wrote the *current* thread's stack to the globally synchronised System.err, which serialises every
+      // thread that logs during an error burst.
       logger.warn(s"$name: ${e.getMessage} with stack trace: ${sw.toString}")
       val _ = lila.mon.round.error.other.increment()
-      Thread.dumpStack()
   }
 
   def roomId = RoomId(gameId)

--- a/modules/round/src/main/RoundDuct.scala
+++ b/modules/round/src/main/RoundDuct.scala
@@ -623,7 +623,6 @@ final private[round] class RoundDuct(
       e.printStackTrace(new PrintWriter(sw))
       logger.warn(s"$name: ${e.getMessage} with stack trace: ${sw.toString}")
       val _ = lila.mon.round.error.other.increment()
-      Thread.dumpStack()
   }
 
   def roomId = RoomId(gameId)

--- a/modules/round/src/main/RoundSocket.scala
+++ b/modules/round/src/main/RoundSocket.scala
@@ -218,6 +218,25 @@ final class RoundSocket(
     val _ = lila.mon.round.ductCount.update(rounds.size)
   }
 
+  /* Round ducts are unbounded and have no overflow counter, so a game whose duct stops draining accumulates
+   * messages invisibly: every Tick, every QuietFlag, every move. Reporting the deepest queue makes that
+   * visible, and registering it lets a stall dump attribute the backlog to round play.
+   */
+  system.scheduler.scheduleWithFixedDelay(60 seconds, 60 seconds) { () =>
+    val _ = lila.mon.duct.depth("round").record(deepestRoundQueue().toLong)
+  }
+
+  private def deepestRoundQueue(): Int = {
+    var deepest = 0
+    rounds.foreachValue { duct =>
+      val size = duct.queueSize
+      if (size > deepest) deepest = size
+    }
+    deepest
+  }
+
+  lila.common.DuctRegistry.register("round.deepest", () => deepestRoundQueue())
+
   private val terminationDelay = new TerminationDelay(system.scheduler, 1 minute, finishRound)
 }
 

--- a/modules/round/src/main/RoundSocket.scala
+++ b/modules/round/src/main/RoundSocket.scala
@@ -218,6 +218,17 @@ final class RoundSocket(
     val _ = lila.mon.round.ductCount.update(rounds.size)
   }
 
+  private def deepestRoundQueue(): Int = {
+    var deepest = 0
+    rounds.foreachValue { duct =>
+      val size = duct.queueSize
+      if (size > deepest) deepest = size
+    }
+    deepest
+  }
+
+  lila.common.DuctHealth.register("round.deepest", () => deepestRoundQueue())
+
   private val terminationDelay = new TerminationDelay(system.scheduler, 1 minute, finishRound)
 }
 

--- a/modules/round/src/main/Titivate.scala
+++ b/modules/round/src/main/Titivate.scala
@@ -39,14 +39,32 @@ final private[round] class Titivate(
 
   def scheduleNext(): Unit = { val _ = scheduler.scheduleOnce(5 seconds, self, Run) }
 
+  /* This actor clocks itself: it only schedules its next Run once the current one has completed. So a
+   * ReceiveTimeout means one of two very different things, and the logged message alone cannot tell them
+   * apart. Either the previous run's future never completed (runPending), which points at the stream or
+   * whatever it awaits, or the run did complete and the scheduled Run message never arrived, which points at
+   * the scheduler or the dispatcher. Recording that distinction is the point of the fields below.
+   */
+  // written from the stream's completion callback, read from the actor thread
+  @volatile private var runId        = 0L
+  @volatile private var runStartedAt = 0L
+  @volatile private var runPending   = false
+
   def receive = {
     case ReceiveTimeout =>
-      val msg = "Titivate timed out!"
-      logBranch.error(msg)
+      val stuckForMillis = if (runPending) (System.nanoTime() - runStartedAt) / 1000000 else -1L
+      val msg            = "Titivate timed out!"
+      logBranch.error(
+        s"$msg run=$runId pending=$runPending stuckFor=${stuckForMillis}ms\n" +
+          s"ducts:\n${lila.common.DuctRegistry.dump()}"
+      )
       lila.mon.round.titivate.timeout.increment()
       throw new RuntimeException(msg)
 
     case Run =>
+      runId += 1
+      runStartedAt = System.nanoTime()
+      runPending = true
       gameRepo.count(_.checkable) foreach { total =>
         lila.mon.round.titivate.total.record(total)
         gameRepo
@@ -64,7 +82,10 @@ final private[round] class Titivate(
           )
           .monSuccess(_.round.titivate.time)
           .logFailure(logBranch)
-          .addEffectAnyway(scheduleNext())
+          .addEffectAnyway {
+            runPending = false
+            scheduleNext()
+          }
       }
   }
 

--- a/modules/round/src/main/Titivate.scala
+++ b/modules/round/src/main/Titivate.scala
@@ -39,14 +39,22 @@ final private[round] class Titivate(
 
   def scheduleNext(): Unit = { val _ = scheduler.scheduleOnce(5 seconds, self, Run) }
 
+  @volatile private var runId        = 0L
+  @volatile private var runStartedAt = 0L
+  @volatile private var runPending   = false
+
   def receive = {
     case ReceiveTimeout =>
-      val msg = "Titivate timed out!"
-      logBranch.error(msg)
+      val stuckForMillis = if (runPending) (System.nanoTime() - runStartedAt) / 1000000 else -1L
+      val msg            = "Titivate timed out!"
+      logBranch.error(s"$msg run=$runId pending=$runPending stuckFor=${stuckForMillis}ms")
       lila.mon.round.titivate.timeout.increment()
       throw new RuntimeException(msg)
 
     case Run =>
+      runId += 1
+      runStartedAt = System.nanoTime()
+      runPending = true
       gameRepo.count(_.checkable) foreach { total =>
         lila.mon.round.titivate.total.record(total)
         gameRepo
@@ -64,7 +72,10 @@ final private[round] class Titivate(
           )
           .monSuccess(_.round.titivate.time)
           .logFailure(logBranch)
-          .addEffectAnyway(scheduleNext())
+          .addEffectAnyway {
+            runPending = false
+            scheduleNext()
+          }
       }
   }
 

--- a/modules/tournament/src/main/CreatedOrganizer.scala
+++ b/modules/tournament/src/main/CreatedOrganizer.scala
@@ -27,15 +27,30 @@ final private class CreatedOrganizer(
     { val _ = scheduler.scheduleOnce(2 seconds, self, Tick) }
   }
 
+  /* Self-clocking actor: the next Tick is only scheduled once the current one finishes. A ReceiveTimeout
+   * therefore means either the previous tick's stream never completed, or it did and the scheduled Tick was
+   * never delivered. Those have opposite causes, so record which one happened.
+   */
+  @volatile private var tickId        = 0L
+  @volatile private var tickStartedAt = 0L
+  @volatile private var tickPending   = false
+
   def receive = {
 
     case ReceiveTimeout =>
-      val msg = "tournament.CreatedOrganizer timed out!"
-      pairingLogger.error(msg)
+      val stuckForMillis = if (tickPending) (System.nanoTime() - tickStartedAt) / 1000000 else -1L
+      val msg            = "tournament.CreatedOrganizer timed out!"
+      pairingLogger.error(
+        s"$msg tick=$tickId pending=$tickPending stuckFor=${stuckForMillis}ms\n" +
+          s"ducts:\n${lila.common.DuctRegistry.dump()}"
+      )
       lila.mon.tournament.createdOrganizer.timeout.increment()
       throw new RuntimeException(msg)
 
     case Tick =>
+      tickId += 1
+      tickStartedAt = System.nanoTime()
+      tickPending = true
       tournamentRepo.shouldStartCursor
         .documentSource()
         .mapAsync(1) { tour =>
@@ -48,7 +63,10 @@ final private class CreatedOrganizer(
         .toMat(Sink.ignore)(Keep.right)
         .run()
         .monSuccess(_.tournament.createdOrganizer.tick)
-        .addEffectAnyway(scheduleNext())
+        .addEffectAnyway {
+          tickPending = false
+          scheduleNext()
+        }
         .discard
   }
 }

--- a/modules/tournament/src/main/CreatedOrganizer.scala
+++ b/modules/tournament/src/main/CreatedOrganizer.scala
@@ -57,7 +57,7 @@ final private class CreatedOrganizer(
         .run()
         .monSuccess(_.tournament.createdOrganizer.tick)
         .addEffect { tours =>
-          if (tours > 0) pairingLogger.info(s"CreatedOrganizer tick=$tickId tours=$tours")
+          if (tours > 1) pairingLogger.info(s"CreatedOrganizer tick=$tickId tours=$tours")
         }
         .addEffectAnyway {
           val elapsed = (System.nanoTime() - tickStartedAt) / 1000000

--- a/modules/tournament/src/main/CreatedOrganizer.scala
+++ b/modules/tournament/src/main/CreatedOrganizer.scala
@@ -53,11 +53,17 @@ final private class CreatedOrganizer(
           }
         }
         .log(getClass.getName)
-        .toMat(Sink.ignore)(Keep.right)
+        .toMat(lila.common.LilaStream.sinkCount)(Keep.right)
         .run()
         .monSuccess(_.tournament.createdOrganizer.tick)
+        .addEffect { tours =>
+          if (tours > 0) pairingLogger.info(s"CreatedOrganizer tick=$tickId tours=$tours")
+        }
         .addEffectAnyway {
+          val elapsed = (System.nanoTime() - tickStartedAt) / 1000000
           tickPending = false
+          if (elapsed > 3000)
+            pairingLogger.info(s"CreatedOrganizer slow tick=$tickId elapsed=${elapsed}ms")
           scheduleNext()
         }
         .discard

--- a/modules/tournament/src/main/CreatedOrganizer.scala
+++ b/modules/tournament/src/main/CreatedOrganizer.scala
@@ -27,15 +27,23 @@ final private class CreatedOrganizer(
     { val _ = scheduler.scheduleOnce(2 seconds, self, Tick) }
   }
 
+  @volatile private var tickId        = 0L
+  @volatile private var tickStartedAt = 0L
+  @volatile private var tickPending   = false
+
   def receive = {
 
     case ReceiveTimeout =>
-      val msg = "tournament.CreatedOrganizer timed out!"
-      pairingLogger.error(msg)
+      val stuckForMillis = if (tickPending) (System.nanoTime() - tickStartedAt) / 1000000 else -1L
+      val msg            = "tournament.CreatedOrganizer timed out!"
+      pairingLogger.error(s"$msg tick=$tickId pending=$tickPending stuckFor=${stuckForMillis}ms")
       lila.mon.tournament.createdOrganizer.timeout.increment()
       throw new RuntimeException(msg)
 
     case Tick =>
+      tickId += 1
+      tickStartedAt = System.nanoTime()
+      tickPending = true
       tournamentRepo.shouldStartCursor
         .documentSource()
         .mapAsync(1) { tour =>
@@ -48,7 +56,10 @@ final private class CreatedOrganizer(
         .toMat(Sink.ignore)(Keep.right)
         .run()
         .monSuccess(_.tournament.createdOrganizer.tick)
-        .addEffectAnyway(scheduleNext())
+        .addEffectAnyway {
+          tickPending = false
+          scheduleNext()
+        }
         .discard
   }
 }


### PR DESCRIPTION
We periodically see DuctSequencer timeouts and periodic-actor ReceiveTimeouts fire together across unrelated subsystems, and the existing logs cannot distinguish the possible causes. This adds enough instrumentation to tell them apart. No behavioural change is intended beyond the two fixes noted at the end.

DuctSequencer previously logged only "timed out after 5 seconds". That message conflates three different failures. The timeout clock started when the task was dequeued, so queue wait time was invisible, and withTimeout abandons the underlying future rather than cancelling it, so nothing recorded whether the task later finished, finished very late, or never finished at all. Each task now carries an id, an enqueue timestamp, and the queue depth it saw on arrival, and an observer on the real future logs any completion that outlives the timeout. Reading the result:

  - timeout, then a late completion just over the limit: genuinely slow work.
  - timeout, then a late completion much later: the task's continuations were not being run.
  - timeout with no late completion at all: the future never completed, which means a lost callback or an unfulfilled promise.
  - large wait with a large depth at enqueue: head-of-line blocking in the sequencer itself.
  - large wait with an empty queue at enqueue: the duct was not being run, which points outside the duct.

DuctRegistry records every duct's queue depth and in-flight task so that a stall can be attributed to a specific duct instead of inferred from scattered timeout logs. Round ducts are unbounded and had no depth metric at all, so a game whose duct stopped draining accumulated messages invisibly; RoundSocket now reports the deepest round queue.

StallDetector runs two probes on a dedicated thread, outside both resources it measures, so it keeps reporting while they are saturated. It measures how long the default execution context takes to run a no-op task, and how late the akka scheduler fires a short timer, with the scheduler callback delivered on a private thread so a saturated pool cannot contaminate that reading. Together the two readings identify the failure mode: context latency alone means pool exhaustion, both together mean the JVM is descheduled, and neither means the work is genuinely waiting on something external. When either crosses the threshold it logs duct state and a thread dump summarised by top stack frame. Configured under `stall` in base.conf and disableable.

Titivate, CreatedOrganizer and RelayFetch all clock themselves, only scheduling their next tick once the current one completes, so a ReceiveTimeout means either the previous run never completed or the scheduled tick was never delivered. They now record which.

Two fixes come along with this. Duct and BoundedDuct now drain their queue when the process function throws synchronously; previously the state ref was left marked busy and that duct never ran another task for the lifetime of the JVM, silently hanging every future behind it. And RoundDuct's generic error branch no longer calls Thread.dumpStack, which wrote to the globally synchronised System.err and serialised every logging thread during an error burst; the error's own stack trace is already in the message above it.